### PR TITLE
Transaction header. ChainDB delete payer #93, #94

### DIFF
--- a/libraries/eosiolib/chaindb.h
+++ b/libraries/eosiolib/chaindb.h
@@ -38,9 +38,9 @@ int32_t chaindb_service(account_name_t code, cursor_t, void* data, const size_t 
 
 primary_key_t chaindb_available_primary_key(account_name_t code, scope_t scope, table_name_t table);
 
-int32_t chaindb_insert(account_name_t code, scope_t scope, account_name_t payer, table_name_t, primary_key_t, void* data, size_t);
-int32_t chaindb_update(account_name_t code, scope_t scope, account_name_t payer, table_name_t, primary_key_t, void* data, size_t);
-int32_t chaindb_delete(account_name_t code, scope_t scope, table_name_t, primary_key_t);
+int32_t chaindb_insert(account_name_t code, scope_t scope, table_name_t, account_name_t payer, primary_key_t, void* data, size_t);
+int32_t chaindb_update(account_name_t code, scope_t scope, table_name_t, account_name_t payer, primary_key_t, void* data, size_t);
+int32_t chaindb_delete(account_name_t code, scope_t scope, table_name_t, account_name_t payer, primary_key_t);
 
 void chaindb_ram_state(account_name_t code, scope_t scope, table_name_t, primary_key_t, bool);
 

--- a/libraries/eosiolib/multi_index.hpp
+++ b/libraries/eosiolib/multi_index.hpp
@@ -796,11 +796,11 @@ private:
             multidx_->modify(*itr, payer, std::forward<Lambda&&>(updater));
         }
 
-        const_iterator erase(const_iterator itr) const {
+        const_iterator erase(const_iterator itr, const account_name_t payer = eosio::name()) const {
             chaindb_assert(itr != cend(), "cannot pass end iterator to erase");
             const auto& obj = *itr;
             ++itr;
-            multidx_->erase(obj);
+            multidx_->erase(obj, payer);
             return itr;
         }
 
@@ -1018,16 +1018,16 @@ public:
         return primary_idx_.require_find(pk, error_msg);
     }
 
-    const_iterator erase(const_iterator itr) const {
+    const_iterator erase(const_iterator itr, const account_name_t payer = eosio::name()) const {
         chaindb_assert(itr != end(), "cannot pass end iterator to erase");
 
         const auto& obj = *itr;
         ++itr;
-        erase(obj);
+        erase(obj, payer);
         return itr;
     }
 
-    void erase(const T& obj) const {
+    void erase(const T& obj, const account_name_t payer = eosio::name()) const {
         const auto& itm = static_cast<const item&>(obj);
 
         CHAINDB_ANOTHER_CONTRACT_PROTECT(
@@ -1038,7 +1038,7 @@ public:
 
         auto pk = primary_key_extractor_type()(obj);
         remove_object_from_cache(pk);
-        chaindb_delete(get_code(), get_scope(), table_name(), pk);
+        chaindb_delete(get_code(), get_scope(), table_name(), payer, pk);
     }
 
     void move_to_ram(const T& obj) const {

--- a/libraries/eosiolib/transaction.hpp
+++ b/libraries/eosiolib/transaction.hpp
@@ -69,9 +69,11 @@ namespace eosio {
       uint32_t        ref_block_prefix;
       unsigned_int    max_net_usage_words = 0UL; /// number of 8 byte words this transaction can serialize into after compressions
       uint8_t         max_cpu_usage_ms = 0UL; /// number of CPU usage units to bill transaction for
+      unsigned_int    max_ram_kbytes = 0UL; /// number of RAM kbytes to bill transaction for
+      unsigned_int    max_storage_kbytes = 0UL; /// number of STORAGE kbytes to bill transaction for
       unsigned_int    delay_sec = 0UL; /// number of seconds to delay transaction, default: 0
 
-      EOSLIB_SERIALIZE( transaction_header, (expiration)(ref_block_num)(ref_block_prefix)(max_net_usage_words)(max_cpu_usage_ms)(delay_sec) )
+      EOSLIB_SERIALIZE( transaction_header, (expiration)(ref_block_num)(ref_block_prefix)(max_net_usage_words)(max_cpu_usage_ms)(max_ram_kbytes)(max_storage_kbytes)(delay_sec) )
    };
 
    /**


### PR DESCRIPTION
Resolve #93:
- Add upper limit on RAM and STORAGE to transaction header

Resolve #94:
- Add payer to chaindb delete operation

This PR is part of GolosChain/CyberWay#732